### PR TITLE
Deployment improvements + configurable timeout

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,36 @@
+### ---------------------------------
+### Mandatory (in production) values:
+### ---------------------------------
+
+# Secret key for Django:
+CTRL_SECRET_KEY="django-insecure-abcde"
+
+# Contents of /etc/olimp-control/key stored on remote machines.
+CTRL_AUTH_KEY="very_secret_olimp-control.py_key"
+
+# Postgres database hostname:
+CTRL_DB_HOST="postgres-db"
+
+# Postgres database password:
+CTRL_DB_PASSWORD="test123"
+
+### ---------------------------------
+### Optional values:
+### ---------------------------------
+# Postgres database port, username, and database name.
+# These are the default values (matching the Postgres Docker image)
+# used when omitted from .env:
+# CTRL_DB_PORT="5432"
+# CTRL_DB_USER="postgres"
+# CTRL_DB_NAME="postgres"
+
+# CTRL_PRODUCTION controls Django environment: dev or prod.
+# Empty string ("") or unset means dev; anything else means prod.
+# This value is set by docker-compose where needed.
+# CTRL_PRODUCTION="True"
+
+# CTRL_STATIC_ROOT controls the `manage.py collectstatic` output.
+# The Docker image sets this to /ctrl/static by default, which is mounted on the
+# same volume that is used by Nginx. Not needed in the dev environment,
+# since Django serves static files automatically in that case.
+# CTRL_STATIC_ROOT="/ctrl/static"

--- a/ctrl/apiviews.py
+++ b/ctrl/apiviews.py
@@ -3,13 +3,14 @@ import json
 
 from django.http import HttpResponse
 from django.utils import timezone
+from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 
 from .models import CheckIn, Computer, UnknownComputer
 
 
 X_LMIO_AUTH = "X-lmio-auth"
-AUTH_KEY = "abcde".encode("utf-8")
+AUTH_KEY = settings.CTRL_AUTH_KEY.encode("utf-8")
 
 
 def _make_response(status_code, body, hmac_key=AUTH_KEY):
@@ -27,7 +28,7 @@ def _process_request_basics(request):
         resp_body = "Invalid authentication data"
         status = 403
         return _make_response(status, resp_body)
-    
+
     try:
         body = json.loads(request.body)
     except json.JSONDecodeError as e:

--- a/ctrl/models.py
+++ b/ctrl/models.py
@@ -2,8 +2,7 @@ from django.db import models
 from django.db.models import Count, Q, When, Case, Value, BooleanField, Subquery, OuterRef
 from django.db.models.functions import Now
 from django.contrib.auth.models import User
-from django.utils import timezone
-from datetime import timedelta
+from constance import config
 
 
 class Location(models.Model):
@@ -35,7 +34,7 @@ class ComputerQuerySet(models.QuerySet):
         )
 
     def with_online_status(self):
-        threshold = Now() - timedelta(seconds=5)
+        threshold = Now() - config.MACHINE_OFFLINE_THRESHOLD
         return (
             self.with_last_checkin()
             .annotate(

--- a/ctrl_srv/settings.py
+++ b/ctrl_srv/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 import os
 from pathlib import Path
+from datetime import timedelta
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -43,6 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'constance',
 ]
 
 MIDDLEWARE = [
@@ -188,3 +190,12 @@ DATE_FORMAT = "Y-m-d"
 DATETIME_FORMAT = "Y-m-d H:i:s"
 SHORT_DATE_FORMAT = "Y-m-d"
 SHORT_DATETIME_FORMAT = "Y-m-d H:i:s"
+
+# constance config
+CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'
+CONSTANCE_CONFIG = {
+    'MACHINE_OFFLINE_THRESHOLD': (
+        timedelta(seconds=90),
+        'Maximum time since last machine check-in before it is considered offline'
+    )
+}

--- a/ctrl_srv/settings.py
+++ b/ctrl_srv/settings.py
@@ -34,6 +34,7 @@ def get_env_or_crash_in_prod(key, default_in_dev=""):
 
 
 CTRL_SECRET_KEY = get_env_or_crash_in_prod("CTRL_SECRET_KEY", default_in_dev=DEFAULT_SECRET_KEY)
+CTRL_AUTH_KEY = get_env_or_crash_in_prod("CTRL_AUTH_KEY", default_in_dev='abcde')
 CTRL_STATIC_ROOT = os.environ.get("CTRL_STATIC_ROOT")
 CTRL_DB_HOST = get_env_or_crash_in_prod("CTRL_DB_HOST")
 CTRL_DB_PORT = os.environ.get("CTRL_DB_PORT", default="5432")

--- a/ctrl_srv/settings.py
+++ b/ctrl_srv/settings.py
@@ -21,13 +21,24 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 DEFAULT_SECRET_KEY = 'django-insecure-3pm&fv1w3u5m)ogno056o8=@!(qmk*+x4rcv=_%7pykcfd4wx9'
 
 # Environment variables
-CTRL_SECRET_KEY = os.environ.get("CTRL_SECRET_KEY", default=DEFAULT_SECRET_KEY)
 CTRL_PRODUCTION = not not os.environ.get("CTRL_PRODUCTION")
+
+
+def get_env_or_crash_in_prod(key, default_in_dev=""):
+    value = os.environ.get(key)
+    if value:
+        return value
+    if not CTRL_PRODUCTION:
+        return default_in_dev
+    raise KeyError(f'Expected environment variable `{key}` to be set in production')
+
+
+CTRL_SECRET_KEY = get_env_or_crash_in_prod("CTRL_SECRET_KEY", default_in_dev=DEFAULT_SECRET_KEY)
 CTRL_STATIC_ROOT = os.environ.get("CTRL_STATIC_ROOT")
-CTRL_DB_HOST = os.environ.get("CTRL_DB_HOST")
+CTRL_DB_HOST = get_env_or_crash_in_prod("CTRL_DB_HOST")
 CTRL_DB_PORT = os.environ.get("CTRL_DB_PORT", default="5432")
 CTRL_DB_USER = os.environ.get("CTRL_DB_USER", default="postgres")
-CTRL_DB_PASSWORD = os.environ.get("CTRL_DB_PASSWORD")
+CTRL_DB_PASSWORD = get_env_or_crash_in_prod("CTRL_DB_PASSWORD")
 CTRL_DB_NAME = os.environ.get("CTRL_DB_NAME", default="postgres")
 
 DEBUG = not CTRL_PRODUCTION
@@ -82,7 +93,7 @@ WSGI_APPLICATION = 'ctrl_srv.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
-if CTRL_PRODUCTION:
+if CTRL_DB_HOST:
     DATABASES = {
         'default': {
             "ENGINE": "django.db.backends.postgresql",
@@ -93,13 +104,15 @@ if CTRL_PRODUCTION:
             "NAME": CTRL_DB_NAME,
         }
     }
-else:
+elif not CTRL_PRODUCTION:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': BASE_DIR / 'db.sqlite3',
         }
     }
+else:
+    raise ValueError('Refusing to run sqlite in production; set CTRL_DB_HOST env variable')
 
 
 # Password validation

--- a/ctrl_srv/settings.py
+++ b/ctrl_srv/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 import os
 from pathlib import Path
-from django.utils.log import DEFAULT_LOGGING
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -23,7 +22,6 @@ DEFAULT_SECRET_KEY = 'django-insecure-3pm&fv1w3u5m)ogno056o8=@!(qmk*+x4rcv=_%7py
 # Environment variables
 CTRL_SECRET_KEY = os.environ.get("CTRL_SECRET_KEY", default=DEFAULT_SECRET_KEY)
 CTRL_PRODUCTION = not not os.environ.get("CTRL_PRODUCTION")
-CTRL_LOG_LEVEL = os.environ.get("CTRL_LOG_LEVEL", default="INFO")
 CTRL_STATIC_ROOT = os.environ.get("CTRL_STATIC_ROOT")
 CTRL_DB_HOST = os.environ.get("CTRL_DB_HOST")
 CTRL_DB_PORT = os.environ.get("CTRL_DB_PORT", default="5432")
@@ -120,14 +118,47 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-LOGGING = DEFAULT_LOGGING
-LOGGING["handlers"]["console"]["level"] = CTRL_LOG_LEVEL
-LOGGING["loggers"].update({
-    "django.db.backends": {
-        "level": "DEBUG",
-        "handlers": ["console"],
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "require_debug_false": {
+            "()": "django.utils.log.RequireDebugFalse",
+        },
+        "require_debug_true": {
+            "()": "django.utils.log.RequireDebugTrue",
+        },
     },
-})
+    "formatters": {
+        "django.server": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "[{server_time}] {message}",
+            "style": "{",
+        }
+    },
+    "handlers": {
+        "console": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+        },
+        "django.server": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "django.server",
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+        "django.server": {
+            "handlers": ["django.server"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/5.1/topics/i18n/

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,6 +6,7 @@ services:
 
   ctrl: 
     environment:
+      CTRL_PRODUCTION:
       CTRL_DB_HOST: "db"
       CTRL_DB_PASSWORD: "test123"
 

--- a/prod_entrypoint.sh
+++ b/prod_entrypoint.sh
@@ -7,4 +7,10 @@ python manage.py collectstatic --clear --noinput
 python manage.py migrate --noinput
 
 # for worker count, see: https://gunicorn.org/design/#how-many-workers
-su ctrl -c "python -m gunicorn --control-socket /tmp/gunicorn_ctrl.ctl --bind 0.0.0.0:8000 --workers $(( 2 * $(nproc) + 1 )) ctrl_srv.wsgi:application"
+su ctrl -c "python -m gunicorn \
+    --control-socket /tmp/gunicorn_ctrl.ctl     \
+    --bind 0.0.0.0:8000                         \
+    --workers $(( 2 * $(nproc) + 1 ))           \
+    --error-logfile -                           \
+    --access-logfile -                          \
+    ctrl_srv.wsgi:application"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.8.1
 Django==5.2.12
+django-constance==4.3.5
 gunicorn==25.1.0
 packaging==26.0
 psycopg2-binary==2.9.11


### PR DESCRIPTION
- Various deployment improvements:
  - HMAC key is passed though environment variables.
  - Some environment variables (Django secret key, HMAC key) are given default values in dev environment, while raising an error when missing in production.
  - `.env.sample` file.
  - Logging fixed in production environment.
- Added configurable timeout in admin page, with 1 minute 30 second default:
<img width="907" height="209" alt="image" src="https://github.com/user-attachments/assets/e7dc7b48-6bd5-4885-8df8-fd14abaa5185" />
